### PR TITLE
Update the content on update command

### DIFF
--- a/ghost-cli/update.md
+++ b/ghost-cli/update.md
@@ -14,17 +14,9 @@ keywords:
 sidebar: "ghost-cli"
 ---
 
-Use the upgrade command to update to the latest version of Ghost and access all of the latest features. 
+The vast majority of upgrades in Ghost are completely automatic. Typically, we release a minor version of Ghost 1-2 times per week.
 
-We recommend that you always run the latest version of Ghost to ensure your site is secure and has access to the best features in Ghost. 
-
-Updating can be done using a single command, `ghost update`, however there are also some preliminary steps such as backups and theme compatibility updates. 
-
-Check out the latest upgrade guides to ensure you carry out all of the necessary steps for a smooth upgrade: 
-
-* [Ghost 1.0](/faq/upgrade-to-ghost-2-0/)
-* [Ghost 2.0](/faq/upgrade-to-ghost-1-0/) (latest major version)
-
+The Ghost-CLI has a single command for upgrades: `ghost update`. 
 
 ## Options
 
@@ -41,3 +33,12 @@ ghost update [version number]
 # Checks what version is currently running
 --version
 ```
+
+## Major upgrades
+
+Every 12-18 months we release a [major version](/faq/major-versions-lts/) which breaks backwards compatibility and requires a more involved upgrade process, including backups and theme compatibility. 
+
+Use the relevant upgrade documentation as a guide to the necessary steps for a smooth upgrade experience: 
+
+* [Upgrading to Ghost 1.0](/faq/upgrade-to-ghost-1-0/)
+* [Upgrading to Ghost 2.0](/faq/upgrade-to-ghost-2-0/)


### PR DESCRIPTION
Updates for the Ghost-CLI `update` command page as discussed to remove mentions of referring to the past / future and fix inaccuracies about the upgrade processes. 