### PR TITLE
🐛 Fixed relative image paths for migration content

### DIFF
--- a/migration/index.md
+++ b/migration/index.md
@@ -23,7 +23,7 @@ Ghost imports from existing blogs via a custom JSON data format, described below
 
 ### Official
 
-**WordPress** users can try the [Ghost WordPress Plugin](http://wordpress.org/plugins/ghost/) to export their data - however this is currently limited to Ghost 1.0. TLDR: You'll need to export content from WordPress, import it into a Ghost 1.0 site, then upgrade that Ghost 1.0 site to the latest version of Ghost. Not ideal! We're working on it. 
+**WordPress** users can try the [Ghost WordPress Plugin](http://wordpress.org/plugins/ghost/) to export their data - however this is currently limited to Ghost 1.0. TLDR: You'll need to export content from WordPress, import it into a Ghost 1.0 site, then upgrade that Ghost 1.0 site to the latest version of Ghost. Not ideal! We're working on it.
 
 ### Non-official
 * **WordPress** users can also try the [wp2ghost](https://github.com/jonhoo/wp2ghost) command-line tool to convert their WordPress export files to Ghost-compatible JSON.
@@ -38,7 +38,7 @@ Once you've generated the JSON go to the Labs Menu (`/ghost/settings/labs/`) on 
 
 ### Importing Images
 
-Ghost can import images within the provided zip. The images need to be located in a folder called `content/images`. 
+Ghost can import images within the provided zip. The images need to be located in a folder called `content/images`.
 
 
 ---
@@ -52,17 +52,17 @@ If no export tools exist for your current blogging system you'll need to create 
 
 First and foremost, your JSON file must contain valid JSON. You can test your file is valid using the [JSONLint](http://jsonlint.com/) online tool.
 
-The file structure can optionally be wrapped in: 
+The file structure can optionally be wrapped in:
 
 ```json
 {
   "db": [...contents here...]
 }
-``` 
+```
 
 Both with and without are valid Ghost JSON files. But you must include a `meta` and a `data` object.
 
-IDs inside the file are usually relative to the file only, so if you have a `post` with `id: 1` and a `posts_tags` object which references `post_id: 1`, then those two things will be linked, but they do not relate to the `post` with `id: 1` in your database. 
+IDs inside the file are usually relative to the file only, so if you have a `post` with `id: 1` and a `posts_tags` object which references `post_id: 1`, then those two things will be linked, but they do not relate to the `post` with `id: 1` in your database.
 
 ### The meta object
 
@@ -78,11 +78,11 @@ The `meta` block expects two keys, `exported_on` and `version`. `exported_on` sh
 ### The data block
 
 ```json
-"data": { 
-  "posts": [{...}, ...], 
-  "tags": [], 
-  "posts_tags": [], 
-  "users": [], 
+"data": {
+  "posts": [{...}, ...],
+  "tags": [],
+  "posts_tags": [],
+  "users": [],
   "roles_users": []
 }
 ```
@@ -181,7 +181,7 @@ All users are given the role of `author` by default. If you want to specify diff
         "roles_users": [
             {
                 "user_id": ObjectId,
-                "role_id": ObjectId 
+                "role_id": ObjectId
             }
         ]
     }
@@ -192,7 +192,7 @@ All users are given the role of `author` by default. If you want to specify diff
 
 ## Troubleshooting
 
-The Ghost importer takes a JSON file to import data. It has been improved to make it far more robust and provide greater information about the status of your import. 
+The Ghost importer takes a JSON file to import data. It has been improved to make it far more robust and provide greater information about the status of your import.
 
 There are a number of ways in which an import file may trigger an **Error** or a **Warning** particularly if the the JSON file was not created by Ghost but by a third-party tool.
 
@@ -204,11 +204,11 @@ An Error or warning should contain a relevant message on why the import was not 
 
 An example of an error would be a JSON file that contains a null email field:
 
-![Import Failed](../images/api/import-failed.png)
+![Import Failed](../../../images/api/import-failed.png)
 
 
 ### Warning
 
-Your blog may contain multiple warnings. These are issues that may want to know about but are not significant enough to prevent the data being imported. Examples of this include a duplicate user (either duplicated in your JSON file or matching an existing user) or a post linked to an unknown user. 
+Your blog may contain multiple warnings. These are issues that may want to know about but are not significant enough to prevent the data being imported. Examples of this include a duplicate user (either duplicated in your JSON file or matching an existing user) or a post linked to an unknown user.
 
-![Import Warnings](../images/api/import-warnings.png)
+![Import Warnings](../../../images/api/import-warnings.png)


### PR DESCRIPTION
The current paths to the added images from 70dd70d60d753c9af03a4a58482291575cc89f33 does not resolve.

Also, my IDE removed some whitespaces.