### PR TITLE
Corrected count.posts verbiage for authors / tags

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -309,7 +309,7 @@ Pages are structured identically to posts. The response object will look the sam
 
 By default, internal tags are always included, use `filter=visibility:"public"` to limit the response directly or use the [tags helper](/api/helpers/#tags) to handle filtering and outputting the response.
 
-Tags that are not associated with a post are not returned. You can supply `includes=count.posts` to retrieve the number of posts associated with a tag.
+Tags that are not associated with a post are not returned. You can supply `include=count.posts` to retrieve the number of posts associated with a tag.
 
 ```json
 {"tags": [{
@@ -327,7 +327,7 @@ Tags that are not associated with a post are not returned. You can supply `inclu
 
 ### Authors
 
-Authors that are not associated with a post are not returned. You can supply `includes=count.posts` to retrieve the number of posts associated with a tag.
+Authors that are not associated with a post are not returned. You can supply `include=count.posts` to retrieve the number of posts associated with an author.
 
 ```json
 {"authors":[{


### PR DESCRIPTION
The Authors section had a copy/paste error from Tags section, and both referred to `includes=count.posts` when it should be `include=count.posts`.