### PR TITLE
💡Updated url helper to correct the usage of the "absolute" property

### DIFF
--- a/handlebars-themes/helpers/encode.md
+++ b/handlebars-themes/helpers/encode.md
@@ -20,7 +20,7 @@ Usage: `{{encode value}}`
 The most obvious example of where this is useful is shown in Casper's `post.hbs`, for outputting a twitter share link:
 
 ```handlebars
-<a class="icon-twitter" href="http://twitter.com/share?text={{encode title}}&url={{url absolute='true'}}"
+<a class="icon-twitter" href="http://twitter.com/share?text={{encode title}}&url={{url absolute=true}}"
     onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">
     <span class="hidden">Twitter</span>
 </a>

--- a/handlebars-themes/helpers/navigation.md
+++ b/handlebars-themes/helpers/navigation.md
@@ -39,7 +39,7 @@ If you want to modify the default markup of the navigation helper, this can be a
     <ul class="nav">
         <!-- Loop through the navigation items -->
         {{#foreach navigation}}
-        <li class="nav-{{slug}}{{#if current}} nav-current{{/if}}"><a href="{{url absolute="true"}}">{{label}}</a></li>
+        <li class="nav-{{slug}}{{#if current}} nav-current{{/if}}"><a href="{{url absolute=true}}">{{label}}</a></li>
         {{/foreach}}
         <!-- End the loop -->
     </ul>

--- a/handlebars-themes/helpers/url.md
+++ b/handlebars-themes/helpers/url.md
@@ -17,4 +17,4 @@ Usage: `{{url}}`
 
 `{{url}}` outputs the relative url for a post when inside the post scope.
 
-You can force the url helper to output an absolute url by using the absolute option, E.g. `{{url absolute="true"}}`
+You can force the url helper to output an absolute url by using the absolute option, E.g. `{{url absolute=true}}` or `{{url absolute=false}}`


### PR DESCRIPTION
no issue

- the docs were incorrect
- you have to use a boolean instead of a string
- 0.x, 1.x and 2.x work like this. there was never a breaking change
- we might want to reconsider this usage in any of the next major Ghost versions (tracked)

See https://forum.ghost.org/t/strange-behavior-with-absolute-urls/5784/1