### PR TITLE
Added 'canonical_url' field to post resources

### DIFF
--- a/admin/index.md
+++ b/admin/index.md
@@ -421,6 +421,7 @@ By default, the API expects and returns content in the mobiledoc format only. To
             "url": "https://demo.ghost.io/tag/getting-started/"
         },
         "url": "https://demo.ghost.io/welcome/",
+        "canonical_url": null,
         "excerpt": "Welcome, it's great to have you here."
     }
 ]}

--- a/content/index.md
+++ b/content/index.md
@@ -206,7 +206,8 @@ By default, the response for a post will not include these:
     "custom_template":null,
     "primary_author":null,
     "primary_tag":null,
-    "url":"https://demo.ghost.io/welcome/"
+    "url":"https://demo.ghost.io/welcome/",
+    "canonical_url":null
 }]}
 ```
 
@@ -249,6 +250,7 @@ Returns:
     "twitter_description": null,
     "custom_template": null,
     "url": "https://demo.ghost.io/welcome/",
+    "canonical_url": null,
     "authors": [{
         "id": "5951f5fca366002ebd5dbef7",
         "name": "Ghost",


### PR DESCRIPTION
- Added new field due to change in Admin/Content API https://github.com/TryGhost/Ghost/commit/34fad7eaafa7c84ea25c3c671d93bcf430f7ef5e

Currently, we don't have a notion of versions in docs, maybe worth indicating somewhere that API user should be on latest master or point that these specific fields are available since `2.17.0` (or first non-buggy `2.18.1` version)