### PR TITLE
Updated install commands

### DIFF
--- a/ghost-cli/install.md
+++ b/ghost-cli/install.md
@@ -42,10 +42,13 @@ Here are some useful options when using the `ghost install` command:
 
 ```bash
 # Install a specific version (1.0.0 or higher)
-ghost install [version]
+ghost install --[version]
 
 # Install locally for development
 ghost install local
+
+# Install specific version locally
+ghost install --[version] local
 
 # Process manager to run ghost with (default: systemd)
 --process


### PR DESCRIPTION
While covering support this week I had a few questions about migrations from other platforms - and I noticed that there are people out there who are savvy enough to be ideal Ghost(Pro) customers trying to make use of the info on our migrations page here: https://docs.ghost.org/api/migration/

I had one person who has already migrated their content from Medium > WordPress, who was trying to figure out how to use the Ghost WP plugin workaround and getting stuck (understandably). 

I was curious to see if I even knew how to do it, and immediately got tripped up when trying to figure out how to install v1 locally as I couldn't find the command from this page.

This PR is a suggestion to improve the commands listed to be clearer about how to specify a version. Still not sure if this is the best way to do it because using square brackets can be confusing 🤔The only other way I can think of is to actually use `v1` as an example, but this might be encouraging the wrong thing. 

`ghost install --v1`
`ghost install --v1 local`

---
**Related question:** If we're not going to have a clearer migration path in the near future, then would it be worth me doing an FAQ for the current workaround (using the plugin) to send to people who are getting stuck? 

It would make the support process for those tickets smoother - but I'm not so sure if it would actually result in more migrations to Ghost since most people will just put their hands up and say they'll come back later. 

