### PR TITLE
Fix link to @labs helper page from Utility Helpers list

### DIFF
--- a/handlebars-themes/helpers/utility.md
+++ b/handlebars-themes/helpers/utility.md
@@ -26,4 +26,4 @@ Utility helpers are used to perform minor, optional tasks. Use this reference li
 * [translate](/api/handlebars-themes/helpers/translate/)
 * [encode](/api/handlebars-themes/helpers/encode/)
 * [log](/api/handlebars-themes/helpers/log/)
-* [@labs](/api/handlebars-themes/helpers/@labs/)
+* [@labs](/api/handlebars-themes/helpers/labs/)


### PR DESCRIPTION
no issue
- clicking the `@labs` link in the "Available utility helpers" list was showing a 404 because it used `@labs` in the URL instead of `labs`