### PR TITLE
Remove trailing comma

### DIFF
--- a/handlebars-themes/packagejson.md
+++ b/handlebars-themes/packagejson.md
@@ -41,7 +41,7 @@ To reference a working example of a `package.json` file, review the [Casper file
     "config": {
         "posts_per_page": 10,
         "image_sizes": {}
-    },
+    }
 }
 ```
 


### PR DESCRIPTION
The trailing comma in this code snippet breaks JSON validity.